### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
 
+dist: bionic
+
+addons:
+  apt:
+    packages:
+      - libpcre2-dev
+
 arch:
   - arm64
   - amd64
@@ -11,10 +18,13 @@ python:
     - "3.7"
     - "3.8"
     - pypy3
+
 install:
     - pip install .
     - pip install pillow pytest-cov coveralls
+
 script:
     py.test --cov scss
+
 after_success:
     coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ python:
     - "3.8"
     - pypy3
 
+# there is no pypy3 for arm64 on Travis CI      
+jobs:
+  exclude:
+    - arch: arm64
+      python: pypy3
+
 install:
     - pip install .
     - pip install pillow pytest-cov coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: python
+
+arch:
+  - arm64
+  - amd64
+    #  - ppc64le
+    #  - s390x
+
 python:
     - "2.6"
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,9 @@ arch:
     #  - s390x
 
 python:
-    - "2.6"
-    - "2.7"
-    - "3.3"
-    - "3.4"
-    - "3.5"
-    - pypy
+    - "3.6"
+    - "3.7"
+    - "3.8"
     - pypy3
 install:
     - pip install .


### PR DESCRIPTION
Several updates to Travis CI:

- move to use Ubuntu 18.04,
- drop Python 2
- update Python versions (3.6, 3.7, 3.8, pypy3)
- add aarch64 architecture (ppc64le and s390x are added as disabled)